### PR TITLE
Fix auth callback and streaming API

### DIFF
--- a/supabase/functions/chat-stream/index.ts
+++ b/supabase/functions/chat-stream/index.ts
@@ -353,10 +353,10 @@ ${documentContext ?
       const errorText = await response.text();
       console.error('❌ OpenAI API error:', response.status, errorText);
       return new Response(
-        JSON.stringify({ error: `OpenAI API error: ${response.status} - ${errorText}` }),
-        { 
-          status: 500, 
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+        JSON.stringify({ error: errorText }),
+        {
+          status: response.status,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
         }
       )
     }


### PR DESCRIPTION
## Summary
- handle auth callback with getSessionFromUrl and cleanup
- add fetchChatStream helper for SSE
- return proper OpenAI errors from edge function

## Testing
- `npm run lint` *(fails: 4 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687acbfbd8f083259b94462d0ed8ce97