### PR TITLE
Fix extraction trigger and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ This project is built with:
 
 Simply open [Lovable](https://lovable.dev/projects/9e5e2aea-1cf6-4db3-9f6f-d22c90b5d2f5) and click on Share -> Publish.
 
+## Local Testing
+
+Use the included scripts to verify the backend integrations:
+
+### PDF text extraction
+
+```bash
+npx tsx test-pdf-extraction.ts [document-id]
+```
+
+If no `document-id` is provided the script will use your most recent upload.
+
+### OpenAI chat
+
+```bash
+npx tsx test-openai.ts
+```
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/supabase/functions/upload-pdf/index.ts
+++ b/supabase/functions/upload-pdf/index.ts
@@ -175,8 +175,19 @@ serve(async (req) => {
         document_id: documentData.id,
       })
 
-    // TODO: Trigger PDF text extraction function
-    // This would call another edge function to extract text from the PDF
+    // Trigger PDF text extraction in the background
+    const { error: extractError } = await supabaseClient.functions.invoke('extract-pdf-text', {
+      body: { documentId: documentData.id },
+      headers: {
+        // Pass through the same auth header so the function can verify the user
+        Authorization: req.headers.get('Authorization')!,
+        'Content-Type': 'application/json'
+      }
+    })
+
+    if (extractError) {
+      console.error('Text extraction trigger error:', extractError)
+    }
 
     return new Response(
       JSON.stringify({


### PR DESCRIPTION
## Summary
- automatically invoke `extract-pdf-text` when a PDF is uploaded
- document local test scripts for the OpenAI and PDF integrations

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_687bfe84d6f08325aec1b7dcfe11188d