### PR TITLE
Fix auth session handling and cleanup tokens

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,73 +1,31 @@
 import React from 'react';
 import { useAuthSession } from '@/hooks/useAuthSession';
-import { AuthModal } from './AuthModal';
-import { Button } from '@/components/ui/button';
+import { AuthModal } from './AuthModal'
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
   fallback?: React.ReactNode;
 }
 
-export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ 
-  children, 
-  fallback 
-}) => {
-  const { user, isLoading, error } = useAuthSession();
-  const [showAuthModal, setShowAuthModal] = React.useState(false);
-  
-  // Only show auth modal if we're not loading and there's no user
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, fallback }) => {
+  const { user, isLoading } = useAuthSession()
+  const [showAuthModal, setShowAuthModal] = React.useState(false)
+
   React.useEffect(() => {
-    if (!isLoading && !user) {
-      setShowAuthModal(true);
-    } else if (user) {
-      setShowAuthModal(false);
-    }
-  }, [isLoading, user]);
+    if (!isLoading && !user) setShowAuthModal(true)
+  }, [isLoading, user])
 
   if (isLoading) {
     return fallback || (
-      <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 flex items-center justify-center">
-        <div className="text-center space-y-3">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
-          <p className="text-sm text-muted-foreground">Loading...</p>
-        </div>
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
       </div>
-    );
+    )
   }
 
   if (!user) {
-    return (
-      <>
-        <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 flex items-center justify-center">
-          <div className="max-w-md w-full text-center space-y-4 p-6">
-            <h1 className="text-2xl font-semibold">Welcome to OM Intel Chat</h1>
-            <p className="text-muted-foreground">
-              Sign in to upload and analyze commercial real estate documents with AI.
-            </p>
-            {error && (
-              <p className="text-sm text-red-500">
-                {error.message}
-              </p>
-            )}
-            {!showAuthModal && (
-              <Button 
-                onClick={() => setShowAuthModal(true)}
-                className="mt-4"
-              >
-                Sign In with Email
-              </Button>
-            )}
-          </div>
-        </div>
-        <AuthModal 
-          isOpen={showAuthModal} 
-          onClose={() => setShowAuthModal(false)}
-          onSuccess={() => setShowAuthModal(false)}
-        />
-      </>
-    );
+    return <AuthModal isOpen={showAuthModal} onClose={() => setShowAuthModal(false)} onSuccess={() => setShowAuthModal(false)} />
   }
 
-  // User is authenticated - just render children
-  return <>{children}</>;
-};
+  return <>{children}</>
+}

--- a/src/hooks/useAuthSession.ts
+++ b/src/hooks/useAuthSession.ts
@@ -1,186 +1,38 @@
-import { useEffect, useState } from 'react';
-import { Session, User } from '@supabase/supabase-js';
-import { supabase } from '@/integrations/supabase/client';
+import { useEffect, useState } from 'react'
+import { Session, User } from '@supabase/supabase-js'
+import { supabase } from '@/integrations/supabase/client'
 
-interface AuthState {
-  session: Session | null;
-  user: User | null;
-  isLoading: boolean;
-  error: Error | null;
-}
-
-/**
- * Custom hook to manage Supabase authentication session
- * Prevents hanging issues and handles token refresh properly
- */
 export const useAuthSession = () => {
-  const [authState, setAuthState] = useState<AuthState>({
-    session: null,
-    user: null,
-    isLoading: true,
-    error: null,
-  });
+  const [session, setSession] = useState<Session | null>(null)
+  const [user, setUser] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    let mounted = true;
-    let refreshTimer: NodeJS.Timeout;
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session)
+      setUser(data.session?.user ?? null)
+      setIsLoading(false)
+    })
 
-    // Initial session check with timeout
-    const checkSession = async () => {
-      try {
-        // Set a timeout for the session check
-        const timeoutPromise = new Promise<never>((_, reject) => {
-          setTimeout(() => reject(new Error('Session check timeout')), 5000);
-        });
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, sess) => {
+      setSession(sess)
+      setUser(sess?.user ?? null)
+      setIsLoading(false)
+    })
 
-        const sessionPromise = supabase.auth.getSession();
-        
-        const { data: { session }, error } = await Promise.race([
-          sessionPromise,
-          timeoutPromise,
-        ]) as Awaited<typeof sessionPromise>;
-
-        if (!mounted) return;
-
-        if (error) {
-          throw error;
-        }
-
-        setAuthState({
-          session,
-          user: session?.user || null,
-          isLoading: false,
-          error: null,
-        });
-
-        // Set up token refresh timer if we have a session
-        if (session && session.expires_at) {
-          const expiresAt = new Date(session.expires_at * 1000);
-          const refreshAt = new Date(expiresAt.getTime() - 60000); // Refresh 1 minute before expiry
-          const timeout = refreshAt.getTime() - Date.now();
-          
-          if (timeout > 0) {
-            refreshTimer = setTimeout(async () => {
-              if (mounted) {
-                const { data: { session: newSession } } = await supabase.auth.refreshSession();
-                if (mounted && newSession) {
-                  setAuthState(prev => ({
-                    ...prev,
-                    session: newSession,
-                    user: newSession.user,
-                  }));
-                }
-              }
-            }, timeout);
-          }
-        }
-      } catch (error) {
-        console.error('Session check error:', error);
-        if (mounted) {
-          setAuthState({
-            session: null,
-            user: null,
-            isLoading: false,
-            error: error as Error,
-          });
-        }
-      }
-    };
-
-    // Subscribe to auth changes
-    const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      async (event, session) => {
-        if (!mounted) return;
-
-        console.log('Auth state change:', event, session?.user?.email);
-
-        // Clear any existing refresh timer
-        if (refreshTimer) {
-          clearTimeout(refreshTimer);
-        }
-
-        setAuthState({
-          session,
-          user: session?.user || null,
-          isLoading: false,
-          error: null,
-        });
-
-        // Handle token refresh for new sessions
-        if (session && session.expires_at && event !== 'TOKEN_REFRESHED') {
-          const expiresAt = new Date(session.expires_at * 1000);
-          const refreshAt = new Date(expiresAt.getTime() - 60000);
-          const timeout = refreshAt.getTime() - Date.now();
-          
-          if (timeout > 0) {
-            refreshTimer = setTimeout(async () => {
-              if (mounted) {
-                await supabase.auth.refreshSession();
-              }
-            }, timeout);
-          }
-        }
-      }
-    );
-
-    checkSession();
-
-    return () => {
-      mounted = false;
-      subscription.unsubscribe();
-      if (refreshTimer) {
-        clearTimeout(refreshTimer);
-      }
-    };
-  }, []);
+    return () => subscription.unsubscribe()
+  }, [])
 
   const signOut = async () => {
-    try {
-      await supabase.auth.signOut();
-      setAuthState({
-        session: null,
-        user: null,
-        isLoading: false,
-        error: null,
-      });
-    } catch (error) {
-      console.error('Sign out error:', error);
-      setAuthState(prev => ({
-        ...prev,
-        error: error as Error,
-      }));
-    }
-  };
+    await supabase.auth.signOut()
+    setSession(null)
+    setUser(null)
+  }
 
   const getValidToken = async (): Promise<string | null> => {
-    try {
-      const { data: { session }, error } = await supabase.auth.getSession();
-      
-      if (error || !session) {
-        return null;
-      }
+    const { data } = await supabase.auth.getSession()
+    return data.session?.access_token ?? null
+  }
 
-      // Check if token is about to expire
-      const expiresAt = new Date(session.expires_at * 1000);
-      const now = new Date();
-      const timeUntilExpiry = expiresAt.getTime() - now.getTime();
-      
-      // If token expires in less than 2 minutes, refresh it
-      if (timeUntilExpiry < 120000) {
-        const { data: { session: newSession } } = await supabase.auth.refreshSession();
-        return newSession?.access_token || null;
-      }
-
-      return session.access_token;
-    } catch (error) {
-      console.error('Error getting valid token:', error);
-      return null;
-    }
-  };
-
-  return {
-    ...authState,
-    signOut,
-    getValidToken,
-  };
-};
+  return { session, user, isLoading, signOut, getValidToken }
+}

--- a/supabase/migrations/20250716000006_enable_realtime.sql
+++ b/supabase/migrations/20250716000006_enable_realtime.sql
@@ -6,6 +6,8 @@ alter publication supabase_realtime add table public.messages;
 
 -- Enable realtime for threads table
 alter publication supabase_realtime add table public.threads;
+-- Enable realtime for extraction_jobs table
+alter publication supabase_realtime add table public.extraction_jobs;
 
 -- Create function to notify document status changes
 create or replace function notify_document_status_change()


### PR DESCRIPTION
## Summary
- simplify auth session hook
- streamline protected route usage
- remove localStorage token lookups
- ensure extraction jobs get realtime updates

## Testing
- `npm run build`
- `npx -y supabase functions deploy chat-stream extract-pdf-text` *(fails: access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_687e9b3f47988325bc99fc07f14d8614