### PR TITLE
fix: Add AuthService with timeout to prevent auth hanging

### DIFF
--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,0 +1,58 @@
+import { supabase } from '@/integrations/supabase/client';
+import type { Session } from '@supabase/supabase-js';
+
+class AuthService {
+  private static instance: AuthService;
+
+  private constructor() {}
+
+  static getInstance(): AuthService {
+    if (!AuthService.instance) {
+      AuthService.instance = new AuthService();
+    }
+    return AuthService.instance;
+  }
+
+  async getSession(timeout = 3000): Promise<Session | null> {
+    try {
+      const sessionPromise = supabase.auth.getSession();
+      const { data: { session }, error } = await Promise.race([
+        sessionPromise,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('timeout')), timeout)
+        )
+      ]) as Awaited<typeof sessionPromise>;
+
+      if (error || !session) {
+        return null;
+      }
+
+      if (session.expires_at && session.expires_at * 1000 < Date.now()) {
+        return null;
+      }
+
+      return session;
+    } catch {
+      return this.getSessionFromStorage();
+    }
+  }
+
+  private getSessionFromStorage(): Session | null {
+    try {
+      const key = `sb-${supabase.supabaseUrl.split('//')[1].split('.')[0]}-auth-token`;
+      const stored = localStorage.getItem(key);
+      if (!stored) return null;
+      const parsed = JSON.parse(stored);
+      if (parsed.expires_at && parsed.expires_at * 1000 < Date.now()) {
+        return null;
+      }
+      return parsed;
+    } catch (err) {
+      console.error('Failed to read session from storage', err);
+      return null;
+    }
+  }
+}
+
+export const authService = AuthService.getInstance();
+export default AuthService;


### PR DESCRIPTION
## Summary
- add new `AuthService` with a 3‑second timeout and localStorage fallback
- use `AuthService` inside `useSupabase`
- remove insecure localStorage session reads

## Testing
- `npm run lint` *(fails: unexpected any in several files)*

------
https://chatgpt.com/codex/tasks/task_e_687eb4c7b34483259917566d4070c2d8